### PR TITLE
Add github workflow to build and push docker image

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,33 @@
+name: "Healthy"
+
+# only execute workflow on the master branch
+on:
+  push:
+    branches: master
+
+jobs:
+  buildAndPublish:
+    name: Build and publish dev docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # build healthy-api image and push it to docker hub
+      - name: Build and push healthy-api image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: hechi/healthy-api
+          dockerfile: {path}/healthy-api/Dockerfile
+          tags: dev
+      # build healthy-ui image and push it to docker hub
+      - name: Build and push healthy-ui image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: hechi/healthy-ui
+          dockerfile: {path}/healthy-ui/Dockerfile
+          tags: dev


### PR DESCRIPTION
This commit introduces a simple github workflow. The workflow will
build healthy-api and healthy-ui images and push them to the docker
registry und hechi/healthy-[api/ui]. The workflow is only executed
on the master branch and will tag the image as *dev*. To indicate
that the image is the development image.