### PR TITLE
Only allows release workflow on sem. versioning

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -4,7 +4,7 @@ name: "Healthy - releases"
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   healthy-api:


### PR DESCRIPTION
Only allow release workflow to get triggered on tags which have a semantic versioning number like 0.8.7