### PR TITLE
Change location of configuration

### DIFF
--- a/healthy-api/Dockerfile
+++ b/healthy-api/Dockerfile
@@ -17,7 +17,8 @@ FROM adoptopenjdk:11.0.8_10-jre-hotspot
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=builder /home/gradle/build/libs/*.jar /Healthy.jar
-COPY src/main/resources/healthy.yaml /healthy.yaml
+RUN mkdir /config
+COPY src/main/resources/healthy.yaml /config/healthy.yaml
 EXPOSE 8080
 # Run the web service on container startup.
-CMD [ "java", "-jar", "-Dhealthy.config.location=file:healthy.yaml", "/Healthy.jar" ]
+CMD [ "java", "-jar", "-Dhealthy.config.location=file:config/healthy.yaml", "/Healthy.jar" ]

--- a/healthy-api/README.md
+++ b/healthy-api/README.md
@@ -19,6 +19,7 @@ to monitor. I just wanted to know if they are up and running.
 - [X] create docker image
 - [X] query endpoints in a specified time interval.
 - [X] measure response time of endpoint
+- [ ] read healthy.yaml from time to time again, so that we do not need to restart the application
 - [ ] implement basic http authentication
 - [ ] make timeouts configurable
 - [ ] follow redirects
@@ -48,5 +49,5 @@ to monitor. I just wanted to know if they are up and running.
 ```
 * Run docker image with custom healthy.yaml
 ```$xslt
-# docker run -p 80:8080 -v $(pwd)/healthy.yaml:/healthy.yaml healthy
+# docker run -p 80:8080 -v $(pwd)/healthy.yaml:/config/healthy.yaml healthy
 ```


### PR DESCRIPTION
We have to change the location for the healthy.yaml because k8s
deployment does not allow to mount the root folder.