### PR TITLE
Fix loading environmen variables in react

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -13,7 +13,7 @@ services:
     ports: 
       - 8880:80
     environment:
-      REACT_APP_HEALTHY_API_URL: "http://healthy-api:8080"
+      REACT_APP_HEALTHY_API_URL: "http://localhost:8080"
     build: 
       context: ./healthy-ui
     depends_on:

--- a/healthy-ui/.env
+++ b/healthy-ui/.env
@@ -1,0 +1,1 @@
+REACT_APP_HEALTHY_API_URL=http://healthy-api:8080

--- a/healthy-ui/.gitignore
+++ b/healthy-ui/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Temporary env files
+/public/env-config.js
+env-config.js

--- a/healthy-ui/Dockerfile
+++ b/healthy-ui/Dockerfile
@@ -11,4 +11,16 @@ FROM nginx:1.19.1-alpine
 ENV REACT_APP_HEALTHY_API_URL=http://healthy-api:8080
 COPY --from=build-deps /usr/src/app/build /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+# Copy .env file and shell script to container
+WORKDIR /usr/share/nginx/html
+COPY ./env.sh .
+COPY .env .
+
+# Add bash
+RUN apk add --no-cache bash
+
+# Make our shell script executable
+RUN chmod +x env.sh
+
+# Start Nginx server
+CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]

--- a/healthy-ui/env.sh
+++ b/healthy-ui/env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Recreate config file
+rm -rf ./env-config.js
+touch ./env-config.js
+
+# Add assignment 
+echo "window._env_ = {" >> ./env-config.js
+
+# Read each line in .env file
+# Each line represents key=value pairs
+while read -r line || [[ -n "$line" ]];
+do
+  # Split env variables by character `=`
+  if printf '%s\n' "$line" | grep -q -e '='; then
+    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
+    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+  fi
+
+  # Read value of current variable if exists as Environment variable
+  value=$(printf '%s\n' "${!varname}")
+  # Otherwise use value from .env file
+  [[ -z $value ]] && value=${varvalue}
+  
+  # Append configuration property to JS file
+  echo "  $varname: \"$value\"," >> ./env-config.js
+done < .env
+
+echo "}" >> ./env-config.js

--- a/healthy-ui/package.json
+++ b/healthy-ui/package.json
@@ -16,7 +16,7 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "chmod +x ./env.sh && ./env.sh && cp env-config.js ./public/ && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/healthy-ui/public/index.html
+++ b/healthy-ui/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script src="%PUBLIC_URL%/env-config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/healthy-ui/src/App.js
+++ b/healthy-ui/src/App.js
@@ -16,8 +16,8 @@ const containerBasic = {
   display: "flex",
 }
 
-const healthy_api = process.env.REACT_APP_HEALTHY_API_URL
-  ? process.env.REACT_APP_HEALTHY_API_URL 
+const healthy_api = window._env_.REACT_APP_HEALTHY_API_URL
+  ? window._env_.REACT_APP_HEALTHY_API_URL 
   : "http://localhost:8080"
 
 function App() {


### PR DESCRIPTION
Currently it is not possible to load the enviroment
variables after the build process. The only way is
to trick the nginx by generating an env-config.js
via env.sh which is loading the environment variables
into the file above. This file is later provided by
the nginx and loaded in the react application.

The solution is based on: https://www.freecodecamp.org/news/how-to-implement-runtime-environment-variables-with-create-react-app-docker-and-nginx-7f9d42a91d70/