### PR TITLE
fix openssl legacy issue in build

### DIFF
--- a/healthy-ui/package.json
+++ b/healthy-ui/package.json
@@ -16,8 +16,8 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "start": "chmod +x ./env.sh && ./env.sh && cp env-config.js ./public/ && react-scripts start",
-    "build": "react-scripts build",
+    "start": "chmod +x ./env.sh && ./env.sh && cp env-config.js ./public/ && react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Make build and run of frontend with openssl legacy support

FYI

https://github.com/nodejs/node/pull/40119
https://github.com/nodejs/node/issues/40455