### PR TITLE
fix jvm plugin version for kotlin

### DIFF
--- a/healthy-api/Dockerfile
+++ b/healthy-api/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official gradle image to create a build artifact.
 # https://hub.docker.com/_/gradle
-FROM gradle:7-jdk11 as builder
+FROM gradle:8-jdk11 as builder
 
 # Copy local code to the container image.
 COPY build.gradle.kts .

--- a/healthy-api/build.gradle.kts
+++ b/healthy-api/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.7.10"
+    id("org.springframework.boot") version "2.7.12"
     id("io.spring.dependency-management") version "1.1.0"
-    kotlin("jvm") version "2.7.10"
-    kotlin("plugin.spring") version "2.7.10"
+    kotlin("jvm") version "1.8.21"
+    kotlin("plugin.spring") version "1.8.21"
 }
 
 group = "me.hechenberger"

--- a/healthy-api/gradle/wrapper/gradle-wrapper.properties
+++ b/healthy-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I commited wrongly the version for the jvm plugin for kotlin while trying to fix the snakeyaml issue from the commit before. This commit fixes the version for jvm plugin.