### PR TITLE
enable push to docker hub

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -23,10 +23,12 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: healthy-api
+          push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/healthy-api:dev
       # build healthy-ui image and push it to docker hub
       - name: Build and push healthy-ui image
         uses: docker/build-push-action@v4
         with:
           context: healthy-ui
+          push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/healthy-ui:dev

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: healthy-api
+          push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/healthy-api:${{ env.RELEASE_VERSION }}
 
   healthy-ui:
@@ -45,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: healthy-ui
+          push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/healthy-ui:${{ env.RELEASE_VERSION }}
 
   release_healthy:


### PR DESCRIPTION
By default the push is now false. This commit changes the push to true, so the docker image is uploaded to dockerhub.